### PR TITLE
Fix Credit Card Payment Method.

### DIFF
--- a/app/code/community/Uecommerce/Mundipagg/Model/Standard.php
+++ b/app/code/community/Uecommerce/Mundipagg/Model/Standard.php
@@ -919,6 +919,8 @@ class Uecommerce_Mundipagg_Model_Standard extends Mage_Payment_Model_Method_Abst
             $helper = Mage::helper('mundipagg');
             $session = Mage::getSingleton('checkout/session');
             $mundipaggData = $session->getMundipaggData();
+            $orderIncrementId = $order->getIncrementId();
+            $logLabel = "Order #{$orderIncrementId}";
 
             //Post data
             $postData = Mage::app()->getRequest()->getPost();


### PR DESCRIPTION
# What?
Fix Credit Card Payment Method.

# Why?
When making transactions that won't  be authorized by the simulator, the system shows incorrect message to the buyer, instead of the Not Authorized message. On Magento, the status of the sale was incorrect too, being showed as "Pending" when should be "Canceled".

# How?
Declare and set $logLabel variable.