### PR TITLE
Adiciona type ao composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,16 @@
 {
     "name": "mundipagg/magentoone",
     "description": "This is a payment module to ease integration with Mundipagg Gateway",
+    "type": "magento-module",
     "authors": [
         {
             "name": "Mundipagg Embeddables team",
             "email": "embeddables@mundipagg.com"
         }
     ],
+    "require": {
+        "magento-hackathon/magento-composer-installer": "3.*"
+    },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.1"
     },


### PR DESCRIPTION
### Whats?
O composer não reconhece o módulo como sendo do magento por esse motivo não copia os arquivos para as pastas corretas.

### Why?
Para conseguir instalar o módulo via composer

### How?
Colocando type: magento-module e require do magento-hackathon/magento-composer-installer.  Isso fará que o repositório seja reconhecido como um módulo do magento e jogara os arquivos para as pastas corretas de acordo com o arquivo modman