### PR TITLE
Fix boleto payment method.

### DIFF
--- a/app/code/community/Uecommerce/Mundipagg/Model/Boleto.php
+++ b/app/code/community/Uecommerce/Mundipagg/Model/Boleto.php
@@ -54,6 +54,7 @@ class Uecommerce_Mundipagg_Model_Boleto extends Uecommerce_Mundipagg_Model_Stand
         $info->getQuote()->setTotalsCollectedFlag(false)->collectTotals();
 
         $mundipaggDiscounts = $this->getMundipaggDiscounts($info->getQuote());
+        $mundipaggDiscounts = $mundipaggDiscounts === null ? array() : $mundipaggDiscounts;
 
         foreach ($mundipaggDiscounts as $discount) {
             foreach ($info->getQuote()->getAllAddresses() as $address) {


### PR DESCRIPTION
# What?
Fix boleto payment method.

# Why?
When selecting Boleto Payment Method, after filling CPF field and clicking on Continue button, the system shows the message "Unable to set Payment Method" and throws an Exception/Warning. 

# How?
Before the foreach loop, check if $ mundipaggDiscounts variable is null. If it is, set it to an empty array.