### PR TITLE
Enable AuthAndCapture for two credit cards.

### DIFF
--- a/app/code/community/Uecommerce/Mundipagg/Model/Api.php
+++ b/app/code/community/Uecommerce/Mundipagg/Model/Api.php
@@ -115,11 +115,8 @@ class Uecommerce_Mundipagg_Model_Api extends Uecommerce_Mundipagg_Model_Standard
             $num = $helper->getCreditCardsNumber($data['payment_method']);
             $installmentCount = 1;
             $approvalRequest = Mage::getSingleton('checkout/session')->getApprovalRequestSuccess();
-            if ($num > 1 || $approvalRequest === 'partial') {
-                $creditCardOperationEnum = 'AuthOnly';
-            } else {
-                $creditCardOperationEnum = $standard->getCreditCardOperationEnum();
-            }
+
+            $creditCardOperationEnum = $this->getCreditCardOperation($approvalRequest, $standard);
 
             foreach ($data['payment'] as $i => $paymentData) {
                 $creditcardTransactionData = new stdclass();
@@ -2054,5 +2051,22 @@ class Uecommerce_Mundipagg_Model_Api extends Uecommerce_Mundipagg_Model_Standard
             return $result;
         }
         return false;
+    }
+
+    /**
+     * Decide what credit card operation will be used
+     * @param $approvalRequest
+     * @param $standard
+     * @return string
+     */
+    private function getCreditCardOperation($approvalRequest, $standard)
+    {
+        if ($approvalRequest === 'partial') {
+            $creditCardOperation = 'AuthOnly';
+        } else {
+            $creditCardOperation = $standard->getCreditCardOperationEnum();
+        }
+
+        return $creditCardOperation;
     }
 }

--- a/app/code/community/Uecommerce/Mundipagg/Model/Api.php
+++ b/app/code/community/Uecommerce/Mundipagg/Model/Api.php
@@ -2062,11 +2062,8 @@ class Uecommerce_Mundipagg_Model_Api extends Uecommerce_Mundipagg_Model_Standard
     private function getCreditCardOperation($approvalRequest, $standard)
     {
         if ($approvalRequest === 'partial') {
-            $creditCardOperation = 'AuthOnly';
-        } else {
-            $creditCardOperation = $standard->getCreditCardOperationEnum();
+            return 'AuthOnly';
         }
-
-        return $creditCardOperation;
+        return $standard->getCreditCardOperationEnum();
     }
 }


### PR DESCRIPTION
## What?
Enable AuthAndCapture for two credit cards.

## Why?
Allow automatic capture for two credit card orders.

## How?
Remove code block who fix this AuthOnly for two credit cards.