### PR TITLE
Fixed debit payment method on One Step Checkout

### DIFF
--- a/app/code/community/Uecommerce/Mundipagg/Model/Debit.php
+++ b/app/code/community/Uecommerce/Mundipagg/Model/Debit.php
@@ -57,7 +57,7 @@ class Uecommerce_Mundipagg_Model_Debit extends Uecommerce_Mundipagg_Model_Standa
         $info->getQuote()->setTotalsCollectedFlag(false)->collectTotals();
         $info = $this->resetInterest($info);
         $discount = Uecommerce_Mundipagg_Helper_Installments::getRecurrenceDiscount($info->getQuote());
-        $interest = '';
+        $interest = 0;
         foreach ($info->getQuote()->getAllAddresses() as $address) {
             $grandTotal = $address->getGrandTotal();
             $messages = array();


### PR DESCRIPTION
## What? 
Fixed debit payment method on One Step Checkout
## Why?
When proceeding to checkout using One Step Checkout module, the system throws a warning that breaks the process.
 ## How?
Change $interest type to int.