### PR TITLE
Fix new invoice email notification on AuthOnly

### DIFF
--- a/app/code/community/Uecommerce/Mundipagg/Helper/Data.php
+++ b/app/code/community/Uecommerce/Mundipagg/Helper/Data.php
@@ -648,4 +648,21 @@ class Uecommerce_Mundipagg_Helper_Data extends Mage_Core_Helper_Abstract
 
         return 'CEP INVÁLIDO';
     }
+
+    /**
+     * Send New Invoice Email, if it is enabled.
+     *
+     * @param Mage_Sales_Model_Order_Invoice $invoice
+     * @param Mage_Sales_Model_Order $order
+     * @throws Exception
+     */
+    public function sendNewInvoiceEmail(
+        Mage_Sales_Model_Order_Invoice &$invoice,
+        Mage_Sales_Model_Order $order
+    ) {
+        if (Mage::helper('sales')->canSendNewInvoiceEmail($order->getStoreId())) {
+            $invoice->setEmailSent(true);
+            $invoice->sendEmail();
+        }
+    } 
 }

--- a/app/code/community/Uecommerce/Mundipagg/Model/Api.php
+++ b/app/code/community/Uecommerce/Mundipagg/Model/Api.php
@@ -1089,6 +1089,8 @@ class Uecommerce_Mundipagg_Model_Api extends Uecommerce_Mundipagg_Model_Standard
                         return $returnMessage;
                     }
                     if ($return instanceof Mage_Sales_Model_Order_Invoice) {
+                        Mage::helper('mundipagg')->sendNewInvoiceEmail($return,$order);
+
                         $returnMessage = "OK | #{$orderReference} | {$transactionKey} | " . self::TRANSACTION_CAPTURED;
                         $helperLog->info($returnMessage);
                         $helperLog->info("Current order status: " . $order->getStatusLabel());


### PR DESCRIPTION
## What?
Fix new invoice email notification on AuthOnly

## Why?
The new invoice email notification wasn't send after capture, on AuthOnly action.

## How?
Send it after the capture.
