### PR TITLE
Fix OSC double click

### DIFF
--- a/app/design/frontend/rwd/default/template/mundipagg/form.phtml
+++ b/app/design/frontend/rwd/default/template/mundipagg/form.phtml
@@ -605,4 +605,90 @@ if ($recurrent) {
         selectCredcard(this);
     });
     //]]>
+
+    if (typeof OnestepcheckoutPayment !== 'undefined') {
+        OnestepcheckoutPayment.prototype.initObservers = function() {
+            var me = this;
+            //CVV
+            this.cvv.triggerEls.each(function(element){
+                element.observe('click', me.onTooltipTriggerElClick.bind(me));
+            });
+            if(this.cvv.closeEl){
+                this.cvv.closeEl.observe('click', me.onTooltipTriggerElClick.bind(me));
+            }
+            //CID Jump
+            if (this.cvvInput){
+                this.cvvInput.observe('keyup', function(){
+                    var ccTypeContainer = $(this.id.substr(0,this.id.indexOf('_cc_cid')) + '_cc_type');
+                    var ccCidContainer = $(this.id.substr(0,this.id.indexOf('_cc_cid')) + '_cc_cid');
+
+                    if (!ccTypeContainer) {
+                        return true;
+                    }
+                    var ccType = ccTypeContainer.value;
+
+                    if (typeof Validation.creditCartTypes.get(ccType) == 'undefined') {
+                        return false;
+                    }
+                    var re = Validation.creditCartTypes.get(ccType)[1];
+
+                    if(re.test(ccCidContainer.value)){
+                        OSCForm.placeOrderButton.focus();
+                    }
+                });
+            }
+
+            //method changed
+            this.switchMethodInputs.each(function(element) {
+                element.observe('click', function(e) {
+                    me.switchToMethod(element.value);
+                });
+                var block = me.methodAdditionalContainerIdPrefix + element.value;
+                [block + '_before', block, block + '_after'].each(function(elementId){
+                    var element = $(elementId);
+                    if (!element) {
+                        return;
+                    }
+                    Form.getElements(element).each(function(formElement){
+                        var event = formElement.tagName.toUpperCase () == 'SELECT' ? 'change' : 'keyup';
+                        formElement.observe(event, function(e){
+                            var matches = formElement.id.match(/^mundipagg_[\w]+_cc_number$/g);
+                            if(matches !== null && formElement.value.length < 15) {
+                                return;
+                            }
+                            me.savePayment();
+                            Validation.reset(formElement);
+                        });
+                    });
+                });
+            });
+
+            //on block update
+            var me = this;
+            if (!this.wrapContainer.addActionBlocksToQueueAfterFn) {
+                this.wrapContainer.addActionBlocksToQueueAfterFn = function() {
+                    me.storedData = {};
+                    Form.getElements(me.wrapContainer).each(function(element){
+                        var elementId = element.getAttribute('id');
+                        if (elementId) {
+                            me.storedData[elementId] = element.getValue();
+                        }
+                    });
+                }
+            }
+            if (!this.wrapContainer.removeActionBlocksFromQueueAfterFn) {
+                this.wrapContainer.removeActionBlocksFromQueueAfterFn = function() {
+                    Form.getElements(me.wrapContainer).each(function(element){
+                        var elementId = element.getAttribute('id');
+                        if (elementId in me.storedData) {
+                            element.setValue(me.storedData[elementId]);
+                        }
+                    });
+                    me.storedData = {};
+                }
+            }
+        };
+    }
+
+
 </script>


### PR DESCRIPTION
## What?
Fix One Step Checkout double click to send the order

## Why?
To send the order, the customer needs click two times on Order place button on One Step Checkout page.

## How?
Rewrite OneStepCheckout native method at runtime.
