### PR TITLE
Incorrect interest on installments

### DIFF
--- a/app/code/community/Uecommerce/Mundipagg/Helper/Installments.php
+++ b/app/code/community/Uecommerce/Mundipagg/Helper/Installments.php
@@ -338,14 +338,7 @@ class Uecommerce_Mundipagg_Helper_Installments extends Mage_Core_Helper_Abstract
                     if (!$grandTotal) {
                         $grandTotal = $quote->getGrandTotal();
                     }
-
-                    $grandTotalInterest = $grandTotal + ($grandTotal * ($installment[2] / 100));
-
-                    $fee = (round(($grandTotalInterest / $installments), 2) * $installments) - $grandTotal;
-
-                    $balance = round($fee, 2);
-
-                    return $balance;
+                    return ($grandTotal * ($installment[2] / 100));
                 }
             }
         }

--- a/app/code/community/Uecommerce/Mundipagg/Model/Standard.php
+++ b/app/code/community/Uecommerce/Mundipagg/Model/Standard.php
@@ -916,6 +916,15 @@ class Uecommerce_Mundipagg_Model_Standard extends Mage_Payment_Model_Method_Abst
     public function doPayment($payment, $order)
     {
         try {
+
+            $mundipaggInterest = $payment->getOrder()->getMundipaggInterest();
+            if ($mundipaggInterest !== null) {
+                $payment->getOrder()->setBaseGrandTotal(
+                    floatval($payment->getOrder()->getBaseGrandTotal()) + $mundipaggInterest);
+                $payment->getOrder()->save();
+                $payment->save();
+            }
+
             $helper = Mage::helper('mundipagg');
             $session = Mage::getSingleton('checkout/session');
             $mundipaggData = $session->getMundipaggData();


### PR DESCRIPTION
## What?
Incorrect interest on installment.

## Why?
The interests are calculated incorrectly when the purchase have installments, and the interest amount are set as due in Sales > Orders.

## How?
Fixed interest formula and save the order with correct base grand total.