### PR TITLE
Fixed status update on dashboard when ordering with two credit cards

### DIFF
--- a/app/code/community/Uecommerce/Mundipagg/Model/Standard.php
+++ b/app/code/community/Uecommerce/Mundipagg/Model/Standard.php
@@ -562,12 +562,17 @@ class Uecommerce_Mundipagg_Model_Standard extends Mage_Payment_Model_Method_Abst
                     $order->sendNewOrderEmail();
                 }
 
+                $standardPaymentAction = Mage::getStoreConfig('payment/mundipagg_standard/payment_action');
                 // We can capture only if:
                 // 1. Multiple Credit Cards Payment
                 // 2. Anti fraud is disabled
                 // 3. Payment action is "AuthorizeAndCapture"
                 // 4. Authorization amount is equal to grand_total
-                if (count($ccResultCollection) > 1 && $this->getAntiFraud() == 0 && $this->getPaymentAction() == 'order' && $accPaymentAuthorizationAmount == $accGrandTotal
+                if (
+                    count($ccResultCollection) > 1 &&
+                    $this->getAntiFraud() == 0 &&
+                    $standardPaymentAction == 'order' &&
+                    $accPaymentAuthorizationAmount == $accGrandTotal
                 ) {
                     $this->captureAndcreateInvoice($payment);
                 } elseif ($accPaymentAuthorizationAmount < $accGrandTotal) {


### PR DESCRIPTION
## What?
Fixed status update on dashboard when ordering with two credit cards
## Why?
When ordering with the Two Credit Cards payment method, the statuses of the orders aren't updating after checkout with AuthAndCapture.
## How?
Changing one of the conditions to update the status.