### PR TITLE
Fix wrong interest for 1 card

### DIFF
--- a/app/code/community/Uecommerce/Mundipagg/Helper/Installments.php
+++ b/app/code/community/Uecommerce/Mundipagg/Helper/Installments.php
@@ -338,11 +338,6 @@ class Uecommerce_Mundipagg_Helper_Installments extends Mage_Core_Helper_Abstract
                     if (!$grandTotal) {
                         $grandTotal = $quote->getGrandTotal();
                     }
-//                    $interest = $grandTotal * ($installment[2] / 100);
-//                    $grandTotalInterest = $grandTotal + ($grandTotal * ($installment[2] / 100));
-//                    $fee = (round(($grandTotalInterest / $installments), 2) * $installments) - $grandTotal;
-//                    $balance = round($fee, 2);
-//                    return $balance;
 
                     return round($grandTotal * ($installment[2] / 100), 2);
                 }

--- a/app/code/community/Uecommerce/Mundipagg/Helper/Installments.php
+++ b/app/code/community/Uecommerce/Mundipagg/Helper/Installments.php
@@ -338,14 +338,13 @@ class Uecommerce_Mundipagg_Helper_Installments extends Mage_Core_Helper_Abstract
                     if (!$grandTotal) {
                         $grandTotal = $quote->getGrandTotal();
                     }
+//                    $interest = $grandTotal * ($installment[2] / 100);
+//                    $grandTotalInterest = $grandTotal + ($grandTotal * ($installment[2] / 100));
+//                    $fee = (round(($grandTotalInterest / $installments), 2) * $installments) - $grandTotal;
+//                    $balance = round($fee, 2);
+//                    return $balance;
 
-                    $grandTotalInterest = $grandTotal + ($grandTotal * ($installment[2] / 100));
-
-                    $fee = (round(($grandTotalInterest / $installments), 2) * $installments) - $grandTotal;
-
-                    $balance = round($fee, 2);
-
-                    return $balance;
+                    return round($grandTotal * ($installment[2] / 100), 2);
                 }
             }
         }

--- a/app/code/community/Uecommerce/Mundipagg/Model/Standard.php
+++ b/app/code/community/Uecommerce/Mundipagg/Model/Standard.php
@@ -804,7 +804,7 @@ class Uecommerce_Mundipagg_Model_Standard extends Mage_Payment_Model_Method_Abst
         $invoice->save();
 
         $order->setBaseTotalPaid($order->getBaseGrandTotal());
-        $order->setTotalPaid($order->getBaseGrandTotal());
+        $order->setTotalPaid($order->getGrandTotal());
         $order->addStatusHistoryComment('Captured online amount of R$' . $order->getBaseGrandTotal(), false);
         $order->save();
 
@@ -2617,7 +2617,8 @@ class Uecommerce_Mundipagg_Model_Standard extends Mage_Payment_Model_Method_Abst
         $this->createInvoice($order, $payment);
 
         $order->setBaseTotalPaid($order->getBaseGrandTotal());
-        $order->setTotalPaid($order->getBaseGrandTotal());
+//        $order->setTotalPaid($order->getBaseGrandTotal());
+        $order->setTotalPaid($order->getGrandTotal());
         $order->addStatusHistoryComment(
             'Captured online amount of R$' . $order->getBaseGrandTotal(),
             'Pending'

--- a/app/code/community/Uecommerce/Mundipagg/Model/Standard.php
+++ b/app/code/community/Uecommerce/Mundipagg/Model/Standard.php
@@ -2617,7 +2617,6 @@ class Uecommerce_Mundipagg_Model_Standard extends Mage_Payment_Model_Method_Abst
         $this->createInvoice($order, $payment);
 
         $order->setBaseTotalPaid($order->getBaseGrandTotal());
-//        $order->setTotalPaid($order->getBaseGrandTotal());
         $order->setTotalPaid($order->getGrandTotal());
         $order->addStatusHistoryComment(
             'Captured online amount of R$' . $order->getBaseGrandTotal(),


### PR DESCRIPTION
## What?
Module was showing wrong interest for purchase using only one credit card

## Why?
This bug was cause by unnecessary steps when calculating interest and using baseGrandTotal when grandTotal should be used.

## How?
Interest calculate was simplified and the proper total was used.
