### PR TITLE
Add support to Lotus breath one step checkout

### DIFF
--- a/app/design/frontend/base/default/layout/mundipagg.xml
+++ b/app/design/frontend/base/default/layout/mundipagg.xml
@@ -141,4 +141,21 @@
             </block>
         </reference>
     </idecheckoutvm_index_index>
+
+    <lotusbreath_onestepcheckout_index_index translate="label">
+        <reference name="head">
+            <action method="addItem">
+                <type>skin_css</type>
+                <name>css/mundipagg.css</name>
+            </action>
+        </reference>
+        <reference name="before_body_end">
+            <block type="page/html_head" name="extra_js" as="extra_js" after="-" template="mundipagg/extras.phtml">
+                <action method="addItem">
+                    <type>js</type>
+                    <name>uecommerce/mundipagg.js</name>
+                </action>
+            </block>
+        </reference>
+    </lotusbreath_onestepcheckout_index_index>
 </layout>


### PR DESCRIPTION
Whats?
Add support entry on layout xml file to Lotus Breath one step checkout

Why?
The module don't work without this when users have Lotus Breath one step checkout enabled.

How?
Adding the last entry on app/design/frontend/base/default/layout/mundipagg.xml, at line 145 to 161.