### PR TITLE
Remove with error status

### DIFF
--- a/app/code/community/Uecommerce/Mundipagg/Model/Standard.php
+++ b/app/code/community/Uecommerce/Mundipagg/Model/Standard.php
@@ -1148,6 +1148,8 @@ class Uecommerce_Mundipagg_Model_Standard extends Mage_Payment_Model_Method_Abst
                             $statusWithError = Uecommerce_Mundipagg_Model_Enum_CreditCardTransactionStatusEnum::WITH_ERROR;
                             Mage::getSingleton('checkout/session')
                                 ->setApprovalRequestSuccess($statusWithError);
+                            Mage::getSingleton('checkout/session')
+                                ->setWithErrorReason($errorCode = $helper->issetOr($i['Description'],'With Error'));
 
                             return $approvalRequest;
                         }
@@ -2225,15 +2227,19 @@ class Uecommerce_Mundipagg_Model_Standard extends Mage_Payment_Model_Method_Abst
         $comment = true
     ) {
         try {
+
+            $msg = Mage::getSingleton('checkout/session')
+                ->getWithErrorReason();
+
             if ($comment) {
                 $order->setState(
                     'pending',
-                    'mundipagg_with_error',
-                    'With Error',
+                    'pending',
+                    'MP - ' . $msg ,
                     false
                 );
             } else {
-                $order->setStatus('mundipagg_with_error');
+                $order->setStatus('pending');
             }
 
             $order->save();

--- a/app/code/community/Uecommerce/Mundipagg/Model/Standard.php
+++ b/app/code/community/Uecommerce/Mundipagg/Model/Standard.php
@@ -1149,7 +1149,7 @@ class Uecommerce_Mundipagg_Model_Standard extends Mage_Payment_Model_Method_Abst
                             Mage::getSingleton('checkout/session')
                                 ->setApprovalRequestSuccess($statusWithError);
                             Mage::getSingleton('checkout/session')
-                                ->setWithErrorReason($errorCode = $helper->issetOr($i['Description'],'With Error'));
+                                ->setWithErrorReason($errorCode = $helper->issetOr($i['Description'], 'With Error'));
 
                             return $approvalRequest;
                         }
@@ -2227,7 +2227,6 @@ class Uecommerce_Mundipagg_Model_Standard extends Mage_Payment_Model_Method_Abst
         $comment = true
     ) {
         try {
-
             $msg = Mage::getSingleton('checkout/session')
                 ->getWithErrorReason();
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Issues      |  mundipagg/plug-team#192
| What?         | Remove with error status
| Why?          | To stop using an non-default status on Magento.
| How?          | Replace with error status by a peding status and an order history entry, informing the error.

![screenshot from 2018-05-07 14-46-40](https://user-images.githubusercontent.com/24816655/39716020-7e89a6d8-5205-11e8-8097-4aae74dda51b.png)
