### PR TITLE
Fix captured amount accumulation

### DIFF
--- a/app/code/community/Uecommerce/Mundipagg/Helper/ProcessOrderStatus.php
+++ b/app/code/community/Uecommerce/Mundipagg/Helper/ProcessOrderStatus.php
@@ -8,13 +8,13 @@ class Uecommerce_Mundipagg_Helper_ProcessOrderStatus extends Mage_Core_Helper_Ab
 {
     const TRANSACTION_CAPTURED = "Transaction captured";
 
-    public function captured($order, $amountToCapture, $transactionKey, $orderReference)
+    public function captured($order, $amountToCapture, $transactionKey, $orderReference, $amountInCents = null)
     {
         $log = new Uecommerce_Mundipagg_Helper_Log(__METHOD__);
         $transactionHelper = Mage::helper('mundipagg/transaction');
         
         try {
-            $return = $transactionHelper->captureTransaction($order, $amountToCapture, $transactionKey);
+            $return = $transactionHelper->captureTransaction($order, $amountToCapture, $transactionKey, $amountInCents);
         } catch (Exception $e) {
             $errMsg = $e->getMessage();
             $returnMessage = "OK | #{$orderReference} | {$transactionKey} | ";

--- a/app/code/community/Uecommerce/Mundipagg/Helper/Transaction.php
+++ b/app/code/community/Uecommerce/Mundipagg/Helper/Transaction.php
@@ -12,12 +12,21 @@ class Uecommerce_Mundipagg_Helper_Transaction extends Mage_Core_Helper_Abstract
      * @throws Exception
      * @return string
      */
-    public function captureTransaction(Mage_Sales_Model_Order $order, $amountToCapture, $transactionKey) {
+    public function captureTransaction(Mage_Sales_Model_Order $order, $amountToCapture, $transactionKey, $amountInCents = null) {
 
         $log = new Uecommerce_Mundipagg_Helper_Log(__METHOD__);
         $log->setLogLabel("#{$order->getIncrementId()} | {$transactionKey}");
         $totalPaid = $order->getTotalPaid();
         $grandTotal = $order->getGrandTotal();
+
+        if ($amountInCents !== null) {
+            $amount = floatval($amountInCents * 0.01);
+            if (floatval($grandTotal) != floatval($amount)) {
+                $log->warning('Grand Total differs from amount in mundipagg: ' . $grandTotal . ' != ' . $amount);
+                $grandTotal = $amount;
+            }
+        }
+
         $transaction = null;
         $orderPayment = new Uecommerce_Mundipagg_Model_Order_Payment();
         if (is_null($totalPaid)) {

--- a/app/code/community/Uecommerce/Mundipagg/Model/Api.php
+++ b/app/code/community/Uecommerce/Mundipagg/Model/Api.php
@@ -1378,9 +1378,9 @@ class Uecommerce_Mundipagg_Model_Api extends Uecommerce_Mundipagg_Model_Standard
 
             if (empty($capturedAmountInCents) === false) {
                 $amountToCapture = $capturedAmountInCents * 0.01;
-            } else {
-                $amountInCents = null;
             }
+
+            $amountInCents = intval($data['AmountInCents']);
 
             return $this->processOrderStatus(
                 $status,
@@ -1392,7 +1392,8 @@ class Uecommerce_Mundipagg_Model_Api extends Uecommerce_Mundipagg_Model_Standard
                 $capturedAmountInCents,
                 $data,
                 $transactionData,
-                $statusWithError);
+                $statusWithError,
+                $amountInCents);
         } catch (Exception $e) {
             $returnMessage = "Internal server error | {$e->getCode()} - ErrMsg: {$e->getMessage()}";
 
@@ -2316,14 +2317,15 @@ class Uecommerce_Mundipagg_Model_Api extends Uecommerce_Mundipagg_Model_Standard
         $capturedAmountInCents,
         $data,
         $transactionData,
-        $statusWithError
+        $statusWithError,
+        $amountInCents = null
     ) {
         $helperLog = new Uecommerce_Mundipagg_Helper_Log(__METHOD__);
         $helperOrderStatus = Mage::helper('mundipagg/processOrderStatus');
 
         switch (strtolower($status)) {
             case 'captured':
-                return $helperOrderStatus->captured($order, $amountToCapture, $transactionKey, $orderReference);
+                return $helperOrderStatus->captured($order, $amountToCapture, $transactionKey, $orderReference, $amountInCents);
             case 'paid':
             case 'overpaid':
                 return $helperOrderStatus->paidOverpaid($order, $returnMessageLabel, $capturedAmountInCents, $data, $status);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Issues      |   mundipagg/plug-team#245
| What?         | Fix captured amount accumulation
| Why?          | When capturing the order via notification post, the result was 'Overpaid' in cases that Magento order grand total differs from Mundipagg order grand total by less than one cent.
| How?          | Added a grand total check before capture.