### PR TITLE
Fix compatibility with php version

### DIFF
--- a/app/code/community/Uecommerce/Mundipagg/Helper/Logger.php
+++ b/app/code/community/Uecommerce/Mundipagg/Helper/Logger.php
@@ -3,8 +3,6 @@
 class Uecommerce_Mundipagg_Helper_Logger extends Mage_Core_Helper_Abstract
 {
 
-    const _allowedFileExtensions = array('log', 'txt', 'html', 'csv');
-
     /**
      * @param string $message
      * @param integer $level
@@ -84,10 +82,15 @@ class Uecommerce_Mundipagg_Helper_Logger extends Mage_Core_Helper_Abstract
     {
         $result = false;
         $validatedFileExtension = pathinfo($file, PATHINFO_EXTENSION);
-        if ($validatedFileExtension && in_array($validatedFileExtension, self::_allowedFileExtensions)) {
+        if ($validatedFileExtension && in_array($validatedFileExtension, self::getAllowedFileExtensions())) {
             $result = true;
         }
 
         return $result;
+    }
+
+    protected static function getAllowedFileExtensions()
+    {
+        return ['log', 'txt', 'html', 'csv'];
     }
 }

--- a/app/code/community/Uecommerce/Mundipagg/Model/Api.php
+++ b/app/code/community/Uecommerce/Mundipagg/Model/Api.php
@@ -442,11 +442,10 @@ class Uecommerce_Mundipagg_Model_Api extends Uecommerce_Mundipagg_Model_Standard
         $filteredOrderData = [];
 
         foreach ($orderData as $key => $value) {
-            $transactionData = strpos(strtolower($key),'transactiondata');
+            $transactionData = strpos(strtolower($key), 'transactiondata');
             if (!($value === null || $transactionData === false)) {
                 $filteredOrderData[$key] = $value;
             }
-            continue;
         }
 
         $key = array_keys($filteredOrderData);

--- a/app/code/community/Uecommerce/Mundipagg/Model/Api.php
+++ b/app/code/community/Uecommerce/Mundipagg/Model/Api.php
@@ -438,9 +438,17 @@ class Uecommerce_Mundipagg_Model_Api extends Uecommerce_Mundipagg_Model_Standard
 
     protected function getTransactionTypeDataKeyFromOrderData($orderData)
     {
-        $filteredOrderData = array_filter($orderData,function($value, $key){
-            return !($value === null || strpos(strtolower($key),'transactiondata') === false);
-        },ARRAY_FILTER_USE_BOTH);
+
+        $filteredOrderData = [];
+
+        foreach ($orderData as $key => $value) {
+            $transactionData = strpos(strtolower($key),'transactiondata');
+            if (!($value === null || $transactionData === false)) {
+                $filteredOrderData[$key] = $value;
+            }
+            continue;
+        }
+
         $key = array_keys($filteredOrderData);
         if (count($key) !== 1) {
             return false;


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Issues         | https://github.com/mundipagg/plug-team/issues/282
| What?         | Fix compatibility with php version
| Why?          | To improve compatibility with php version
| How?          | change function array_filter to be compatible with php version 5.5 and create a method to return an array instead of define an array to constant