### PR TITLE
Fix installment reset on checkout

### DIFF
--- a/js/uecommerce/mundipagg.js
+++ b/js/uecommerce/mundipagg.js
@@ -297,6 +297,17 @@ function updateInstallments(ccType, element, total) {
                     }
                 }
 
+                for(j = element.options.length; j > 0; j--) {
+                    var currentOption = element.options[j-1];
+                    element.options[j] = new Option(
+                        currentOption.text,
+                        currentOption.value,
+                        false,
+                        false
+                    );
+                }
+                element.options[0] = new Option('Selecione', '', true, true);
+
                 if (res['brand'] != undefined) {
                     window['brand_' + id.replace('mundipagg_twocreditcards_', '').replace('_cc_number', '')] = res.brand;
                 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Issues | mundipagg/plug-team#312
| What?         | Fix installment reset on checkout
| Why?          | When reloading the installments select, after fill in the credcard number, the previously selected value is lost, and the selection is reseted to 1.
| How?          | Inserting a new option "Selecione" before the installment options, to force customer to reselect the desired installment value.