### PR TITLE
Fix two cards capture wrong behavior

### DIFF
--- a/app/code/community/Uecommerce/Mundipagg/Helper/Installments.php
+++ b/app/code/community/Uecommerce/Mundipagg/Helper/Installments.php
@@ -320,9 +320,12 @@ class Uecommerce_Mundipagg_Helper_Installments extends Mage_Core_Helper_Abstract
                 $all_installments = $this->getInstallments();
             }
 
-            $installmentData = array_filter($all_installments,function($data) use ($installments) {
-                return $data[1] == $installments;
-            });
+            $installmentData = array_filter(
+                $all_installments,
+                function($data) use ($installments) {
+                    return $data[1] == $installments;
+                }
+            );
 
             if (count($installmentData)) {
                 $installment = array_shift($installmentData);

--- a/app/code/community/Uecommerce/Mundipagg/Helper/Installments.php
+++ b/app/code/community/Uecommerce/Mundipagg/Helper/Installments.php
@@ -320,16 +320,12 @@ class Uecommerce_Mundipagg_Helper_Installments extends Mage_Core_Helper_Abstract
                 $all_installments = $this->getInstallments();
             }
 
-            $installmentKey = $installments - 1;
+            $installmentData = array_filter($all_installments,function($data) use ($installments) {
+                return $data[1] == $installments;
+            });
 
-            if (!$installmentKey) {
-                return 0;
-            }
-
-            $helper = Mage::helper('mundipagg');
-            $installment = $helper->issetOr($all_installments[$installmentKey]);
-
-            if ($installment != null && is_array($installment)) {
+            if (count($installmentData)) {
+                $installment = array_shift($installmentData);
                 // check if interest rate is filled in
                 if (isset($installment[2]) && $installment[2] > 0) {
                     if (!$grandTotal) {

--- a/app/code/community/Uecommerce/Mundipagg/Helper/TwoCreditCardsPostNotificationHandler.php
+++ b/app/code/community/Uecommerce/Mundipagg/Helper/TwoCreditCardsPostNotificationHandler.php
@@ -230,11 +230,6 @@ class Uecommerce_Mundipagg_Helper_TwoCreditCardsPostNotificationHandler extends 
             abs($newTotalPaidInCents - $baseGrandTotalInCents) <= 2
         ) {
             $this->setOrderAsProcessing($order, $newTotalPaidInCents);
-            $this->updateAdditionalInformation(
-                $order,
-                $cardPrefix,
-                $this->getCapturedAmountInCents()
-            );
             $order->save();
             $this->addOrderHistoryStatusUpdate($order, $cardPrefix, true);
         }
@@ -364,7 +359,11 @@ class Uecommerce_Mundipagg_Helper_TwoCreditCardsPostNotificationHandler extends 
 
         $order->setTotalPaid($newTotalPaidInCents * 0.01);
 
-        $this->updateAdditionalInformation($order, $cardPrefix, $capturedAmountInCents);
+        $this->updateAdditionalInformation(
+            $order,
+            $cardPrefix,
+            $capturedAmountInCents
+        );
 
         $order->save();
 

--- a/app/code/community/Uecommerce/Mundipagg/Helper/TwoCreditCardsPostNotificationHandler.php
+++ b/app/code/community/Uecommerce/Mundipagg/Helper/TwoCreditCardsPostNotificationHandler.php
@@ -223,11 +223,11 @@ class Uecommerce_Mundipagg_Helper_TwoCreditCardsPostNotificationHandler extends 
         $this->log->info(self::CAPTURED_AMOUNT . $this->getCapturedAmountInCents());
 
         $newTotalPaidInCents = $this->updateCapturedAmount($order, $cardPrefix);
-        $baseGrandTotalInCents = $util->floatToCents($order->getBaseGrandTotal());
+        $grandTotalInCents = $util->floatToCents($order->getGrandTotal());
 
         if (
             $this->getMundipaggOrderStatus() == 'Paid' &&
-            abs($newTotalPaidInCents - $baseGrandTotalInCents) <= 2
+            abs($newTotalPaidInCents - $grandTotalInCents) <= 2
         ) {
             $this->setOrderAsProcessing($order, $newTotalPaidInCents);
             $order->save();

--- a/app/code/community/Uecommerce/Mundipagg/Helper/TwoCreditCardsPostNotificationHandler.php
+++ b/app/code/community/Uecommerce/Mundipagg/Helper/TwoCreditCardsPostNotificationHandler.php
@@ -227,7 +227,7 @@ class Uecommerce_Mundipagg_Helper_TwoCreditCardsPostNotificationHandler extends 
 
         if (
             $this->getMundipaggOrderStatus() == 'Paid' &&
-            $newTotalPaidInCents == $baseGrandTotalInCents
+            abs($newTotalPaidInCents - $baseGrandTotalInCents) <= 2
         ) {
             $this->setOrderAsProcessing($order, $newTotalPaidInCents);
             $this->updateAdditionalInformation(


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| What?         | Fix two cards capture wrong behavior
| Why?          | The order wasn't changed for **processing** after receiving all the card capture notifications, remaining in **pending**
| How?          | Fixed capture calculations.